### PR TITLE
fix: Remove .env from git index going forwards

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-NODE_ENV=development
-LOCALHOST=true
-DEBUG=app:server


### PR DESCRIPTION
Template repo includes a sample .env which now needs removing to store secrets